### PR TITLE
PCX-4413: use ubuntu latest instead of private github runner

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,5 +1,5 @@
-
 name: Pull Request
+
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
@@ -7,22 +7,30 @@ on:
 jobs:
   build:
 
-    runs-on: nodejs
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-      - name: Run Test Script
-        env:
-          CI: true
-          BRANCH_STRATEGY: release
-        run: |
-          env
-          .ci/test.sh
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 14
+        cache: 'npm'
+        
+    - name: Run Test Script
+      env:
+        CI: true
+        BRANCH_STRATEGY: release
+        MERCHANT_NAME: ${{ secrets.MERCHANT_NAME }}
+        MERCHANT_TOKEN: ${{ secrets.MERCHANT_TOKEN }}
+      run: |
+        env
+        npm ci
+        npm test
 
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_FOOTER: "Payoneer's Github Actions"
-        if: failure()
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_FOOTER: "Payoneer's Github Actions"
+      if: failure()


### PR DESCRIPTION
## Jira ticket
[PCX-4413](https://optile.atlassian.net/browse/PCX-4413)  

## Overview/What
Using ubuntu-latest runner, the public runner from github

## Cause/Why
This repo is public and it needs a public runner
